### PR TITLE
Add new class for propodeum

### DIFF
--- a/sibo-edit.obo
+++ b/sibo-edit.obo
@@ -3637,6 +3637,8 @@ name: propodeum
 def: "The area that is located dorsomedially on the metapectal-propodeal complex." [HAO:0001994]
 is_a: SIBO:0000149 ! Anatomical part
 relationship: part_of SIBO:0000105 ! mesosoma
+relationship: dc-contributor https://orcid.org/0000-0002-4239-1500 ! Thiago S. R. Silva
+property_value: seeAlso "https://github.com/obophenotype/sibo/issues/15" xsd:anyURI
 comment: "Created to replace obsolete class SIBO:0000121."
 
 [Typedef]

--- a/sibo-edit.obo
+++ b/sibo-edit.obo
@@ -3635,11 +3635,11 @@ creation_date: 2011-06-25T09:06:06Z
 id: SIBO:0000534
 name: propodeum
 def: "The area that is located dorsomedially on the metapectal-propodeal complex." [HAO:0001994]
+comment: "Created to replace obsolete class SIBO:0000121."
 is_a: SIBO:0000149 ! Anatomical part
 relationship: part_of SIBO:0000105 ! mesosoma
-relationship: dc-contributor https://orcid.org/0000-0002-4239-1500 ! Thiago S. R. Silva
 property_value: seeAlso "https://github.com/obophenotype/sibo/issues/15" xsd:anyURI
-comment: "Created to replace obsolete class SIBO:0000121."
+created_by: https://orcid.org/0000-0002-4239-1500
 
 [Typedef]
 id: adjacent_to

--- a/sibo-edit.obo
+++ b/sibo-edit.obo
@@ -3631,6 +3631,14 @@ is_a: SIBO:0000232 ! Dispersal
 created_by: cdsmith
 creation_date: 2011-06-25T09:06:06Z
 
+[Term]
+id: SIBO:0000534
+name: propodeum
+def: "The area that is located dorsomedially on the metapectal-propodeal complex." [HAO:0001994]
+is_a: SIBO:0000149 ! Anatomical part
+relationship: part_of SIBO:0000105 ! mesosoma
+comment: "Created to replace obsolete class SIBO:0000121."
+
 [Typedef]
 id: adjacent_to
 name: adjacent_to


### PR DESCRIPTION
Closes #15 

Adds a new non-obsolete class for propodeum,following discussion in #15.

The class includes:
- HAO definition
- placement under anatomical part
- part_of relation to mesosoma
- comment referencing obsolete class SIBO:0000121

Since SIBO currently lacks dedicated annotation properties for replacement/deprecation tracking (other than `deprecated`), the connection to the obsolete class is documented via a comment annotation.